### PR TITLE
Assume there exists lround if compiling with g++ in C++11 or later

### DIFF
--- a/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/lpc_flac.c
+++ b/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/lpc_flac.c
@@ -50,7 +50,7 @@
 
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 
-#if !defined(HAVE_LROUND)
+#if (!defined(__GNUC__) && !defined(HAVE_LROUND)) || __cplusplus < 201103L
 #if defined(_MSC_VER)
 #include <float.h>
 #define copysign _copysign


### PR DESCRIPTION
Compiling with GCC-6 fails with:

`../../../JUCE/modules/juce_audio_formats/juce_audio_formats.cpp:110:`
`../../../JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/lpc_flac.c: In function ‘long int juce::FlacNamespace::lround(double)’:`
`../../../JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/lpc_flac.c:60:39: error: ‘long int juce::FlacNamespace::lround(double)’ conflicts with a previous declaration`
`static inline long int lround(double x) {`

GCC-6 doesn't define HAVE_LROUND, but lround is valid in C++ in dialects >= c++11.
