### PR TITLE
List only readable midi ports in the linux input devices list

### DIFF
--- a/JUCE/modules/juce_audio_devices/native/juce_linux_Midi.cpp
+++ b/JUCE/modules/juce_audio_devices/native/juce_linux_Midi.cpp
@@ -387,7 +387,7 @@ static AlsaClient::Port* iterateMidiClient (const AlsaClient::Ptr& client,
     {
         if (snd_seq_query_next_port (seqHandle, portInfo) == 0
             && (snd_seq_port_info_get_capability (portInfo)
-                & (forInput ? SND_SEQ_PORT_CAP_SUBS_WRITE : SND_SEQ_PORT_CAP_SUBS_READ)) != 0)
+                & (forInput ? SND_SEQ_PORT_CAP_SUBS_READ : SND_SEQ_PORT_CAP_SUBS_WRITE)) != 0)
         {
             const String portName = snd_seq_port_info_get_name(portInfo);
 


### PR DESCRIPTION
This fixes issue #176