### PR TITLE
Fixed filter UI component style not updating in initialization.

### DIFF
--- a/src/editor_sections/filter_section.cpp
+++ b/src/editor_sections/filter_section.cpp
@@ -106,7 +106,7 @@ void FilterSection::paintBackground(Graphics& g) {
 
   g.setColour(Colors::control_label_text);
   g.setFont(Fonts::instance()->proportional_regular().withPointHeight(size_ratio_ * 10.0f));
-  
+
   drawTextForComponent(g, TRANS("ENV DEPTH"), fil_env_depth_);
   drawTextForComponent(g, TRANS("KEY TRACK"), keytrack_);
   drawTextForComponent(g, TRANS("DRIVE"), drive_);
@@ -171,6 +171,11 @@ void FilterSection::resized() {
   resizeHighPass(blend_->getRight() + style_label_padding_x, title_width + style_label_padding_y,
                  style_label_width - 2 * style_label_padding_x,
                  filter_type_width - 2 * style_label_padding_y);
+
+  // Filter style is not refreshed on initial opening of the window.
+  // Added safety check in case the filter is not initialiized at this point fot the first time.
+  if (filter_style_ != nullptr)
+    resetResponse();
 
   SynthSection::resized();
 }


### PR DESCRIPTION
UI did not set the filter style after initializing the UI for the first time.

As I don't know the code base well yet this might not be the ideal place to do this but it works and I did additional safety check in case filter_style_ was not initialized at that point under some circumstances to prevent unexpected crashes.